### PR TITLE
dockerize: build a fully functional tracking_services within a docker image

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -34,5 +34,4 @@ RUN cd /tmp && \
 
 # Start tomcat when the container is run
 ENTRYPOINT ["/usr/bin/bash"]
-CMD ["/tmp/run.sh"]
-#CMD ["/usr/libexec/tomcat9/tomcat-start.sh"]
+CMD ["/usr/libexec/tomcat9/tomcat-start.sh"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,13 +1,38 @@
 FROM ubuntu:20.04
 
-
+# Copy the data into the building container
 COPY LICENSE.txt /tmp
 COPY NOTICE.txt /tmp
 COPY src /tmp/src
 COPY pom.xml /tmp
 
+# Point at the JVM for maven building javadoc (may need to be x86 for 32bit)
+ENV CATALINA_HOME=/usr/share/tomcat9
+ENV CATALINA_BASE=/var/lib/tomcat9
+ENV CATALINA_TMPDIR=/tmp
+ENV JAVA_HOME=/usr
+ENV JAVA_OPTS=-Djava.awt.headless=true
+ENV JRE_HOME=/usr
+
+# Tomcat is on the default 8080 port which can be overridden at docker run
+EXPOSE 8080
+
+# Build up the OS
 RUN apt-get update && \
-    apt-get install -y maven
+    apt-get install -y maven \
+                       openjdk-11-jdk-headless \
+                       tomcat9 \
+                       tomcat9-admin
 
-RUN cd /tmp && mvn site && mv package
+# Build the application and deploy it inside the container
+RUN cd /tmp && \
+    mvn site && \
+    mvn package && \
+    cp target/tracking.war ${CATALINA_BASE}/webapps && \
+    echo "cd /tmp ; mvn site:run" > /tmp/run.sh && \
+    chmod 755 /tmp/run.sh
 
+# Start tomcat when the container is run
+ENTRYPOINT ["/usr/bin/bash"]
+CMD ["/tmp/run.sh"]
+#CMD ["/usr/libexec/tomcat9/tomcat-start.sh"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,13 @@
+FROM ubuntu:20.04
+
+
+COPY LICENSE.txt /tmp
+COPY NOTICE.txt /tmp
+COPY src /tmp/src
+COPY pom.xml /tmp
+
+RUN apt-get update && \
+    apt-get install -y maven
+
+RUN cd /tmp && mvn site && mv package
+

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,37 @@
+FROM ubuntu:20.04
+
+# Get version number from command line
+ARG VERSION
+
+# Point at the JVM for maven building javadoc (may need to be x86 for 32bit)
+ENV CATALINA_HOME=/usr/share/tomcat9
+ENV CATALINA_BASE=/var/lib/tomcat9
+ENV CATALINA_TMPDIR=/tmp
+ENV JAVA_HOME=/usr
+ENV JAVA_OPTS=-Djava.awt.headless=true
+ENV JRE_HOME=/usr
+
+# Tomcat is on the default 8080 port which can be overridden at docker run
+EXPOSE 8080
+
+# Build up the OS
+RUN apt-get update && \
+    apt-get install -y maven \
+                       openjdk-11-jdk-headless \
+                       tomcat9 \
+                       tomcat9-admin \
+                       wget
+
+# Build the application and deploy it inside the container
+RUN cd /tmp && \
+    wget https://github.com/NASA-PDS/tracking-service/archive/${VERSION}-SNAPSHOT.tar.gz && \
+    tar --strip-components=1 -zxf ${VERSION}-SNAPSHOT.tar.gz && \
+    mvn site && \
+    mvn package && \
+    cp target/tracking.war ${CATALINA_BASE}/webapps && \
+    echo "cd /tmp ; mvn site:run" > /tmp/run.sh && \
+    chmod 755 /tmp/run.sh
+
+# Start tomcat when the container is run
+ENTRYPOINT ["/usr/bin/bash"]
+CMD ["/usr/libexec/tomcat9/tomcat-start.sh"]

--- a/README.md
+++ b/README.md
@@ -161,3 +161,10 @@ If you want to access snapshots, add the following to your `~/.m2/settings.xml`:
    </profile>
 </profiles>
 ```
+
+# Build product as docker image
+
+The code from a repository:
+```
+docker build --network=host -t tracking_service:$(git rev-parse HEAD) -f Dockerfile.local .
+```

--- a/README.md
+++ b/README.md
@@ -162,9 +162,30 @@ If you want to access snapshots, add the following to your `~/.m2/settings.xml`:
 </profiles>
 ```
 
-# Build product as docker image
+# Docker
 
-The code from a repository:
-```
-docker build --network=host -t tracking_service:$(git rev-parse HEAD) -f Dockerfile.local .
-```
+## Building
+
+### Local Repository
+
+`docker build --network=host -t tracking_service:$(git rev-parse HEAD) -f Dockerfile.local .`
+
+### Release
+
+`docker build --build-arg VERSION=${VERSION} --network=host -t tracking_service:${VERSION} - < Dockerfile.release`
+
+## Running
+
+The image is built to run ??. To verify the build and run the equivalent of `mvn site:run` as describe above, add `/tmp/run.sh` to the end of the docker run command.
+
+All of the run examples below use the host network for simplicity but this can be very insecure. These are just simple examples are not intented to be how to securely run an exposed service. Use the appropriate network in your operations to meet your security needs.
+
+Lastly, using the --port switch of docker run, the 8080 port can be moved without having to rebuild the container.
+
+### Local Repository
+
+`docker run --rm --network=host tracking_service:$(git rev-parse HEAD)`
+
+### Release
+
+`docker run --rm --network=host tracking_service:${VERSION}`

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,11 @@
     <artifactId>pds</artifactId>
     <version>1.4.0</version>
   </parent>
-  
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
   <groupId>gov.nasa.pds</groupId>
   <artifactId>tracking-service</artifactId>
   <version>0.5.0-SNAPSHOT</version>
@@ -193,6 +197,11 @@
       <artifactId>javax.servlet-api</artifactId>
       <version>3.1.0</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.0</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/javax.persistence/persistence-api -->
 	<dependency>


### PR DESCRIPTION
There will be two different docker builds:

1. local: use the current repo to build a tracking services
2. release: use a specific release to build a tracking services

Steps to build the docker image:

1. Use Ubuntu 20.04 as the base OS
2. Install JRE
3. Install maven
4. mvn site package